### PR TITLE
Replace zod with the tree-shakeable zod/mini entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,10 +108,15 @@ would match the literal header `Bearer undefined`.
 
 ## Conventions
 
-- **zod is the validation layer everywhere**, including runtime-validated function signatures via
-  `z.function({...}).implementAsync(...)`. When an `interface X extends z.infer<typeof schema>` is
-  used as an array/element type, the codebase casts `schema as z.ZodType<X, X>` — this is
-  intentional and repository-wide; keep it for consistency. Parsing uniformly uses `parseAsync`.
+- **zod is the validation layer everywhere**, imported as `import * as z from 'zod/mini'` — the
+  tree-shakeable `zod/mini` entrypoint, never bare `'zod'`. Mini has **no method chaining**:
+  wrappers are functions (`z.optional(x)`, `z.nullable(x)`, `z.readonly(x)`, `z.extend(base, {…})`)
+  and refinements go through `.check(…)` (`z.string().check(z.minLength(1))`,
+  `z.array(x).check(z.maxLength(50))`, `z.int().check(z.positive())`). Runtime-validated function
+  signatures via `z.function({...}).implementAsync(...)` work unchanged. When an
+  `interface X extends z.infer<typeof schema>` is used as an array/element type, the codebase casts
+  `schema as z.ZodMiniType<X, X>` (mini's name for `ZodType`) — this is intentional and
+  repository-wide; keep it for consistency. Parsing uniformly uses `parseAsync`.
 - Keep network/`fetch` and `SERVER_ENV` access out of pure logic so it stays unit-testable — see
   `src/clients/youtube/playlist-items.ts` (pure parse + filter) vs `index.ts` (does the fetch).
 - When handling YouTube playlist data, remember deleted/private videos stay in the uploads

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,10 @@ would match the literal header `Bearer undefined`.
 ## Conventions
 
 - **zod is the validation layer everywhere**, imported as `import * as z from 'zod/mini'` — the
-  tree-shakeable `zod/mini` entrypoint, never bare `'zod'`. Mini has **no method chaining**:
-  wrappers are functions (`z.optional(x)`, `z.nullable(x)`, `z.readonly(x)`, `z.extend(base, {…})`)
-  and refinements go through `.check(…)` (`z.string().check(z.minLength(1))`,
+  tree-shakeable entrypoint, never bare `'zod'`. Mini has **no method chaining**: wrappers are
+  functions (`z.optional(x)`, `z.nullable(x)`, `z.readonly(x)`, `z.safeExtend(base, {…})` — prefer
+  `safeExtend` over `extend`, which lets an overlapping key silently replace the base's with an
+  incompatible type) and refinements go through `.check(…)` (`z.string().check(z.minLength(1))`,
   `z.array(x).check(z.maxLength(50))`, `z.int().check(z.positive())`). Runtime-validated function
   signatures via `z.function({...}).implementAsync(...)` work unchanged. When an
   `interface X extends z.infer<typeof schema>` is used as an array/element type, the codebase casts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ npm run test:integration # Playwright integration suite (alias: npm run playwrig
 There is **no `format` script** and `npm run lint` is **ESLint-only** — Prettier is not
 wired into lint or CI. Formatting follows `.prettierrc` (no semicolons, single quotes,
 `printWidth` 100, `prettier-plugin-tailwindcss`); run `npx prettier --write` on changed
-files manually before committing.
+files manually before committing — but **only on code files**. Do not run it on `CLAUDE.md` or
+other markdown: it reformats the whole file (`*emphasis*` → `_emphasis_`, blank lines after list
+intros), burying the real change in unrelated churn. Hand-edit markdown instead.
 
 There are two distinct test layers:
 - **Unit (Vitest, `*.test.ts`)** live in a `__tests__/` directory next to the module they
@@ -41,6 +43,10 @@ Other notes:
 - Node >= 24, ESM (`"type": "module"`). TypeScript is `@tsconfig/strictest` and ESLint is
   `strictTypeChecked` — expect `noUncheckedIndexedAccess`, so index/env access uses bracket
   notation (`process.env['X']`, `styles['title']`).
+- `npm run build` prints **no JS size columns** (only Route/Revalidate/Expire), so bundle-size
+  questions need measuring by hand:
+  `find .next/static/chunks -name '*.js' -exec cat {} + | gzip -c | wc -c`. Compare branches with
+  a clean `.next` each time.
 
 ## Environment
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,6 @@ export default {
   reactStrictMode: true,
   reactCompiler: true,
   experimental: {
-    optimizePackageImports: ['zod'],
+    optimizePackageImports: ['zod/mini'],
   },
 } satisfies NextConfig

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,19 +1,19 @@
 'use server'
 
 import { cache } from 'react'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { createMongoDbClient } from '../clients/mongodb'
 import { Video } from '../models/video'
 import { SERVER_ENV } from '../utils/server-env'
 
 const GetVideosResult = z.object({
-  videos: z.array(Video as z.ZodType<Video, Video>).readonly(),
+  videos: z.readonly(z.array(Video as z.ZodMiniType<Video, Video>)),
 })
 export interface GetVideosResult extends z.infer<typeof GetVideosResult> {}
 const _getVideos = cache(
   z
     .function({
-      output: GetVideosResult as z.ZodType<GetVideosResult, GetVideosResult>,
+      output: GetVideosResult as z.ZodMiniType<GetVideosResult, GetVideosResult>,
     })
     .implementAsync(async function getVideos(): Promise<GetVideosResult> {
       const dbClient = await createMongoDbClient({ connectionString: SERVER_ENV.MONGODB_URI })

--- a/src/app/api/add-channel/route.ts
+++ b/src/app/api/add-channel/route.ts
@@ -13,10 +13,10 @@ const sharedSchema = z.object({
   store: z.optional(z.literal('true')),
 })
 const searchParamsSchema = z.union([
-  z.extend(sharedSchema, {
+  z.safeExtend(sharedSchema, {
     channelId: z.string().check(z.minLength(1)),
   }),
-  z.extend(sharedSchema, {
+  z.safeExtend(sharedSchema, {
     username: z.string().check(z.minLength(1)),
   }),
 ])

--- a/src/app/api/add-channel/route.ts
+++ b/src/app/api/add-channel/route.ts
@@ -1,6 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { createMongoDbClient } from '../../../clients/mongodb'
 import { getChannelInfo } from '../../../clients/youtube'
 import { channelFromInfoItem } from '../../../clients/youtube/channel-from-info-item'
@@ -13,11 +13,11 @@ const sharedSchema = z.object({
   store: z.optional(z.literal('true')),
 })
 const searchParamsSchema = z.union([
-  sharedSchema.extend({
-    channelId: z.string().min(1),
+  z.extend(sharedSchema, {
+    channelId: z.string().check(z.minLength(1)),
   }),
-  sharedSchema.extend({
-    username: z.string().min(1),
+  z.extend(sharedSchema, {
+    username: z.string().check(z.minLength(1)),
   }),
 ])
 

--- a/src/app/api/dump-channels/route.ts
+++ b/src/app/api/dump-channels/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { createMongoDbClient } from '../../../clients/mongodb'
 import { Channel } from '../../../models/channel'
 import { isApiRequestAuthenticated } from '../../../utils/api-helpers'
@@ -8,9 +8,9 @@ import { SERVER_ENV } from '../../../utils/server-env'
 export const revalidate = 0
 
 const Result = z.object({
-  statusCode: z.number().int().positive(),
-  channels: z.array(Channel as z.ZodType<Channel, Channel>).readonly(),
-  message: z.string().min(1),
+  statusCode: z.int().check(z.positive()),
+  channels: z.readonly(z.array(Channel as z.ZodMiniType<Channel, Channel>)),
+  message: z.string().check(z.minLength(1)),
 })
 interface Result extends z.infer<typeof Result> {}
 
@@ -21,7 +21,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse<Result>> =
 
 const handleRequest = z
   .function({
-    input: [z.object({ request: z.unknown() as z.ZodType<NextRequest, NextRequest> })],
+    input: [z.object({ request: z.unknown() as z.ZodMiniType<NextRequest, NextRequest> })],
     output: z.promise(Result),
   })
   .implementAsync(async function handleRequest({ request }): Promise<Result> {

--- a/src/app/api/load-channels/route.ts
+++ b/src/app/api/load-channels/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { createMongoDbClient } from '../../../clients/mongodb'
 import { Channel } from '../../../models/channel'
 import { isApiRequestAuthenticated } from '../../../utils/api-helpers'
@@ -8,7 +8,7 @@ import { SERVER_ENV } from '../../../utils/server-env'
 export const revalidate = 0
 
 const requestBodySchema = z.object({
-  channels: z.array(Channel as z.ZodType<Channel, Channel>).min(1),
+  channels: z.array(Channel as z.ZodMiniType<Channel, Channel>).check(z.minLength(1)),
 })
 
 interface Result {

--- a/src/clients/mongodb/index.ts
+++ b/src/clients/mongodb/index.ts
@@ -1,16 +1,16 @@
 import { type Document, MongoClient } from 'mongodb'
 import { revalidateTag, unstable_cache } from 'next/cache'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { Channel } from '../../models/channel'
 import { Video } from '../../models/video'
 import { normalizeStoredVideo, type StoredVideo } from './normalize-stored-video'
 
-const ChannelSchema = Channel as z.ZodType<Channel, Channel>
-const VideoSchema = Video as z.ZodType<Video, Video>
+const ChannelSchema = Channel as z.ZodMiniType<Channel, Channel>
+const VideoSchema = Video as z.ZodMiniType<Video, Video>
 
 export const createMongoDbClient = z
   .function({
-    input: [z.object({ connectionString: z.string().min(1) })],
+    input: [z.object({ connectionString: z.string().check(z.minLength(1)) })],
   })
   .implementAsync(async function createMongoDbClient({ connectionString }) {
     const databaseName = 'youtube-serverless'
@@ -29,7 +29,7 @@ export const createMongoDbClient = z
 
     const getChannels = z
       .function({
-        output: z.array(ChannelSchema).readonly(),
+        output: z.readonly(z.array(ChannelSchema)),
       })
       .implementAsync(async function getChannels(): Promise<readonly Channel[]> {
         const { collection } = await getCollection<Channel>('channels')
@@ -61,7 +61,7 @@ export const createMongoDbClient = z
 
     const putLatestVideos = z
       .function({
-        input: [z.object({ videos: z.array(VideoSchema).readonly() })],
+        input: [z.object({ videos: z.readonly(z.array(VideoSchema)) })],
         output: z.void(),
       })
       .implementAsync(async function putVideo({ videos }) {
@@ -72,8 +72,8 @@ export const createMongoDbClient = z
 
     const getLatestVideos = z
       .function({
-        input: [z.object({ limit: z.int().positive() })],
-        output: z.array(VideoSchema).readonly(),
+        input: [z.object({ limit: z.int().check(z.positive()) })],
+        output: z.readonly(z.array(VideoSchema)),
       })
       .implementAsync(async function getLatestVideos({ limit }): Promise<Video[]> {
         return await unstable_cache(

--- a/src/clients/youtube/index.ts
+++ b/src/clients/youtube/index.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod'
+import * as z from 'zod/mini'
 import { SERVER_ENV } from '../../utils/server-env'
 import { parseAvailablePlaylistItems, type VideoItem } from './playlist-items'
 
@@ -12,37 +12,37 @@ const YOUTUBE_MAX_RESULTS = 50
 const YOUTUBE_API_TIMEOUT_MS = 10_000
 
 const channelInfoItemSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().check(z.minLength(1)),
   snippet: z.object({
-    title: z.string().min(1),
+    title: z.string().check(z.minLength(1)),
     description: z.string(),
     thumbnails: z.object({
       high: z.object({
-        url: z.string().min(1),
+        url: z.string().check(z.minLength(1)),
       }),
     }),
   }),
   contentDetails: z.object({
     relatedPlaylists: z.object({
-      uploads: z.string().min(1),
+      uploads: z.string().check(z.minLength(1)),
     }),
   }),
 })
 export interface ChannelInfoItem extends z.infer<typeof channelInfoItemSchema> {}
 const channelInfoSchema = z.object({
   /** Not defined when there's no result for given channel ID input parameter. */
-  items: z.optional(z.array(channelInfoItemSchema as z.ZodType<ChannelInfoItem, ChannelInfoItem>)),
+  items: z.optional(z.array(channelInfoItemSchema as z.ZodMiniType<ChannelInfoItem, ChannelInfoItem>)),
 })
 interface ChannelInfo extends z.infer<typeof channelInfoSchema> {}
 
 const getChannelInfoArgsSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('channelId'),
-    channelId: z.string().min(1),
+    channelId: z.string().check(z.minLength(1)),
   }),
   z.object({
     type: z.literal('forUsername'),
-    username: z.string().min(1),
+    username: z.string().check(z.minLength(1)),
   }),
 ])
 export const getChannelInfo = z
@@ -101,9 +101,11 @@ export const getVideosForChannelId = async (channelId: string): Promise<readonly
 }
 
 const ContentDetailsResponseItem = z.object({
-  id: z.string().min(1),
+  id: z.string().check(z.minLength(1)),
   contentDetails: z.object({
-    duration: z.optional(z.string().startsWith('P') as z.ZodType<`P${string}`, `P${string}`>),
+    duration: z.optional(
+      z.string().check(z.startsWith('P')) as z.ZodMiniType<`P${string}`, `P${string}`>
+    ),
   }),
   snippet: z.object({
     liveBroadcastContent: z.enum(['none', 'upcoming', 'live']),
@@ -113,7 +115,7 @@ export interface ContentDetailsResponseItem extends z.infer<typeof ContentDetail
 
 const ContentDetailsResponse = z.object({
   items: z.array(
-    ContentDetailsResponseItem as z.ZodType<ContentDetailsResponseItem, ContentDetailsResponseItem>
+    ContentDetailsResponseItem as z.ZodMiniType<ContentDetailsResponseItem, ContentDetailsResponseItem>
   ),
 })
 export interface ContentDetailsResponse extends z.infer<typeof ContentDetailsResponse> {}
@@ -122,7 +124,7 @@ export const getContentDetailsForVideos = z
   .function({
     input: [
       z.object({
-        videoIds: z.array(z.string().min(1)).max(YOUTUBE_MAX_RESULTS),
+        videoIds: z.array(z.string().check(z.minLength(1))).check(z.maxLength(YOUTUBE_MAX_RESULTS)),
       }),
     ],
   })
@@ -150,8 +152,8 @@ export const getContentDetailsForVideos = z
 
 export const isVideoServedAsShort = z
   .function({
-    input: [z.object({ videoId: z.string().min(1) })],
-    output: z.boolean().nullable(),
+    input: [z.object({ videoId: z.string().check(z.minLength(1)) })],
+    output: z.nullable(z.boolean()),
   })
   .implementAsync(async function isVideoServedAsShort({ videoId }): Promise<boolean | null> {
     try {

--- a/src/clients/youtube/playlist-items.ts
+++ b/src/clients/youtube/playlist-items.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod'
+import * as z from 'zod/mini'
 
 // Schema + filtering for the YouTube `playlistItems.list` response, kept in its
 // own module (free of `SERVER_ENV`/`fetch`) so the parse-and-filter logic can be
@@ -9,7 +9,7 @@ import * as z from 'zod'
 // `status.privacyStatus` that isn't `public`/`unlisted`. We keep the schema
 // tolerant of those so parsing never throws, then filter them out below.
 const thumbnailSchema = z.object({
-  url: z.string().min(1),
+  url: z.string().check(z.minLength(1)),
   width: z.number(),
   height: z.number(),
 })
@@ -19,31 +19,31 @@ const AVAILABLE_PRIVACY_STATUSES = new Set(['public', 'unlisted'])
 
 const videoItemSchema = z.object({
   contentDetails: z.object({
-    videoId: z.string().min(1),
-    videoPublishedAt: z.string().min(1).optional(),
+    videoId: z.string().check(z.minLength(1)),
+    videoPublishedAt: z.optional(z.string().check(z.minLength(1))),
   }),
   status: z.object({
     privacyStatus: z.string(),
   }),
   snippet: z.object({
-    publishedAt: z.string().min(1),
-    channelId: z.string().min(1),
-    title: z.string().min(1),
+    publishedAt: z.string().check(z.minLength(1)),
+    channelId: z.string().check(z.minLength(1)),
+    title: z.string().check(z.minLength(1)),
     description: z.string(),
     thumbnails: z.object({
-      default: thumbnailSchema.optional(),
-      medium: thumbnailSchema.optional(),
-      high: thumbnailSchema.optional(),
-      standard: thumbnailSchema.optional(),
-      maxres: thumbnailSchema.optional(),
+      default: z.optional(thumbnailSchema),
+      medium: z.optional(thumbnailSchema),
+      high: z.optional(thumbnailSchema),
+      standard: z.optional(thumbnailSchema),
+      maxres: z.optional(thumbnailSchema),
     }),
-    channelTitle: z.string().min(1),
+    channelTitle: z.string().check(z.minLength(1)),
   }),
 })
 export interface VideoItem extends z.infer<typeof videoItemSchema> {}
 
 const videoSchema = z.object({
-  items: z.array(videoItemSchema as z.ZodType<VideoItem, VideoItem>),
+  items: z.array(videoItemSchema as z.ZodMiniType<VideoItem, VideoItem>),
 })
 
 /**

--- a/src/hooks/use-search-params.ts
+++ b/src/hooks/use-search-params.ts
@@ -2,7 +2,7 @@
 
 import { useSearchParams as useNextSearchParams, usePathname } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
-import * as z from 'zod'
+import * as z from 'zod/mini'
 
 const SearchParams = z.object({
   showShorts: z.optional(z.literal('1')),

--- a/src/models/channel.ts
+++ b/src/models/channel.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod'
+import * as z from 'zod/mini'
 
 export const Channel = z.strictObject({
   channelId: z.string(),

--- a/src/models/video.ts
+++ b/src/models/video.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod'
+import * as z from 'zod/mini'
 
 export const ShortDetectionMethod = z.enum(['youtube-shorts-url', 'duration', 'unknown'])
 export type ShortDetectionMethod = z.infer<typeof ShortDetectionMethod>
@@ -12,7 +12,7 @@ export const Video = z.strictObject({
   channelThumbnail: z.string(),
   channelLink: z.string(),
   title: z.string(),
-  durationInSeconds: z.nullable(z.number().int().nonnegative()),
+  durationInSeconds: z.nullable(z.int().check(z.nonnegative())),
   isShort: z.boolean(),
   shortDetectionMethod: ShortDetectionMethod,
 })

--- a/src/utils/server-env.ts
+++ b/src/utils/server-env.ts
@@ -1,12 +1,12 @@
-import * as z from 'zod'
+import * as z from 'zod/mini'
 
 const envSchema = z.object({
-  SECRET: z.string().min(1),
-  CRON_SECRET: z.optional(z.string().min(1)),
+  SECRET: z.string().check(z.minLength(1)),
+  CRON_SECRET: z.optional(z.string().check(z.minLength(1))),
 
-  YOUTUBE_API_KEY: z.string().min(1),
+  YOUTUBE_API_KEY: z.string().check(z.minLength(1)),
 
-  MONGODB_URI: z.string().startsWith('mongodb') as z.ZodType<
+  MONGODB_URI: z.string().check(z.startsWith('mongodb')) as z.ZodMiniType<
     `mongodb${string}`,
     `mongodb${string}`
   >,


### PR DESCRIPTION
Swaps every `import * as z from 'zod'` over to `zod/mini`, the tree-shakeable entrypoint.

## Why

`zod/mini` drops **12.1 KB gzipped (-6.0%)** off the client bundle — measured by building `main` and this branch and gzipping `.next/static/chunks`:

| | main (`zod`) | this branch (`zod/mini`) | delta |
|---|---|---|---|
| client JS, gzipped | 202.6 KB | 190.6 KB | **-12.1 KB (-6.0%)** |
| client JS, raw | 699.4 KB | 650.6 KB | -48.8 KB (-7.0%) |

Only one client file (`src/hooks/use-search-params.ts`) imports zod, so the saving is essentially the whole zod core dropping out of the client bundle in favour of mini's much smaller subset.

## What changed

`zod/mini` has no method chaining, so wrappers become functions and refinements move to `.check()`:

- `.optional()` / `.nullable()` / `.readonly()` → `z.optional(x)` / `z.nullable(x)` / `z.readonly(x)`
- `base.extend({…})` → `z.safeExtend(base, {…})`
- `z.string().min(1)` → `z.string().check(z.minLength(1))`
- `z.array(x).max(50)` → `z.array(x).check(z.maxLength(50))`
- `z.number().int().positive()` → `z.int().check(z.positive())`
- `z.string().startsWith('P')` → `z.string().check(z.startsWith('P'))`
- `z.ZodType<X, X>` → `z.ZodMiniType<X, X>` (mini's name for the same type)

Extension uses **`z.safeExtend`, not `z.extend`**: `safeExtend` type-constrains overlapping keys, so an extension can't silently replace a base key with an incompatible type. Nothing overlaps today (`sharedSchema` has `store`; the extensions add `channelId`/`username`), so it's behaviour-neutral here — it guards future edits.

Two more things worth calling out, because they carried the risk:

- **`z.function({…}).implementAsync(…)` works unchanged in mini**, so the repo-wide runtime-validated-signature convention survives as-is. Same for `parseAsync` / `safeParseAsync` / `.shape`.
- **The refinements still reject.** Each translated check was verified to fail on bad input (empty string, over-length array, wrong prefix) rather than silently becoming a no-op — that's the quiet failure mode this kind of migration invites.

`optimizePackageImports` was pointing at `'zod'`, which nothing imports anymore, so it now points at `'zod/mini'`. CLAUDE.md's zod convention section is updated to document the mini idioms.

## Verification

`npm run typecheck`, `npm run lint` (0 errors), and `npm run test:unit` (64/64) all pass, and both branches build clean. No behaviour change is intended — this is a pure import/API-surface swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)